### PR TITLE
Pass options to mm_import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Most suitable for small datasets.
 Then add these settings to `settings.json`:
 
 	{
-	  mindmeld: {
-	    password: "PASSWORD",
-	    allowImport: false
+	  "mindMeld": {
+	    "password": "PASSWORD",
+	    "allowImport": false
 	  }
 	}
 
 ## Usage
-Mind Meld exposes 2 DDP methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.mindmeld.password`).
+Mind Meld exposes 2 DDP methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.mindMeld.password`).
 
 ## `mm_export(collectionName, password)`
 The `mm_export` method returns a dump of the collection. You generally don't call this method yourself.
@@ -25,13 +25,13 @@ The `mm_export` method returns a dump of the collection. You generally don't cal
 ## `mm_import({sourceUrl, sourcePassword, collections, localPassword, ...options})`
 The `mm_import` method first calls `mm_export` on another Meteor instance, retrieving a collection dump, and imports the dump locally.
 
-Because this method default removes all records from your database, you have to specifically enable it using `Meteor.settings.mindmeld.allowImport`. Normally you would disable this on your production system, and enable it on your development and acceptance environments.
+Because this method default removes all records from your database, you have to specifically enable it using `Meteor.settings.mindMeld.allowImport`. Normally you would disable this on your production system, and enable it on your development and acceptance environments.
 
 Parameters:
 * `sourceUrl` URL to the meteor instance that you want to copy the data from. Has to have this package installed.
-* `sourcePassword` Meteor.settings.mindmeld.password of that Meteor instance.
+* `sourcePassword` Meteor.settings.mindMeld.password of that Meteor instance.
 * `collections` array of names of the collections you want to import. Use the (usually lowercased) name of the mongo collection.
-* `localPassword` Meteor.settings.mindmeld.password of the destination Meteor instance that you're calling this method on.
+* `localPassword` Meteor.settings.mindMeld.password of the destination Meteor instance that you're calling this method on.
 * `keepCurrentData` optionally choose to append the imported data to the existing data in your database. Default `false`, will remove all entries from the collection before importing.
 * `bypassCollection2` optionally choose to [bypass collection2's validation](https://github.com/aldeed/meteor-collection2#inserting-or-updating-bypassing-collection2-entirely), cleaning and autovalues. Defaults to `false` if collection2 is installed, and will use collection2 to validate and clean entries when they're imported.
 * `enableHooks` optionally choose to enable before and after submit hooks, if the collection-hooks package is installed. Defaults to `false`, where the hooks will not be executed, instead using [collection.direct](https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # q42:mind-meld
 
-Easily transfer collection data from one Meteor instance to another, using DDP methods. Used to easily get production data on your development or acceptance environment.
+Easily transfer collection data from one Meteor instance to another. Used to easily get production data on your development or acceptance environment without having to access your mongo database.
 Most suitable for small datasets.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Then add these settings to `settings.json`:
 ## Usage
 Mind Meld exposes 2 DDP methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.mindMeld.password`).
 
-## `MindMeld.export(collectionName, password)`
+## `MindMeld.export(collectionName, password, callBack)`
 The `mm_export` method returns a dump of the collection. You generally don't call this method yourself.
 
 ## `MindMeld.import({sourceUrl, sourcePassword, collections, localPassword, ...options})`
@@ -40,7 +40,10 @@ Parameters:
 
 To export collection `col1`:
 
-	MindMeld.export('col1', 'password');
+	MindMeld.export('col1', 'password', (err,res) => {
+		if (err) console.warn(err);
+		console.log(res);
+	});
 
 To import collections `col1` & `col2` from instance `http://xx.yy.zz`:
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
 # q42:mind-meld
 
-Easily transfer collection data from one Meteor instance to another. Most suitable for small datasets.
+Easily transfer collection data from one Meteor instance to another, using DDP methods. Used to easily get production data on your development or acceptance environment.
+Most suitable for small datasets.
 
 ## Installation
 
 	meteor add q42:mind-meld
 
+Then add these settings to `settings.json`:
+
+	{
+	  mindmeld: {
+	    password: "PASSWORD",
+	    allowImport: false
+	  }
+	}
+
 ## Usage
-Mind Meld exposes 2 methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.MIND_MELD_TOKEN`).
+Mind Meld exposes 2 DDP methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.mindmeld.password`).
 
 ## `mm_export(collectionName, password)`
-The `mm_export` method returns a dump of the collection.
+The `mm_export` method returns a dump of the collection. You generally don't call this method yourself.
 
-## `mm_import(url, [collections], destinationPassword, sourcePassword)`
+## `mm_import({sourceUrl, sourcePassword, collections, localPassword, ...options})`
 The `mm_import` method first calls `mm_export` on another Meteor instance, retrieving a collection dump, and imports the dump locally.
 
-_note that the first password is for the Meteor instance you're call the import method on (destination) while the second password is for the instance you're importing from (source)._
+Because this method default removes all records from your database, you have to specifically enable it using `Meteor.settings.mindmeld.allowImport`. Normally you would disable this on your production system, and enable it on your development and acceptance environments.
 
-_note that the collection name you're using is the same one you use when creating the collection. So if you're using `const Products = new Mongo.Collection('products')` then you should use `products` (lowercase)._
+Parameters:
+* `sourceUrl` URL to the meteor instance that you want to copy the data from. Has to have this package installed.
+* `sourcePassword` Meteor.settings.mindmeld.password of that Meteor instance.
+* `collections` array of names of the collections you want to import. Use the (usually lowercased) name of the mongo collection.
+* `localPassword` Meteor.settings.mindmeld.password of the destination Meteor instance that you're calling this method on.
+* `keepCurrentData` optionally choose to append the imported data to the existing data in your database. Default `false`, will remove all entries from the collection before importing.
+* `bypassCollection2` optionally choose to [bypass collection2's validation](https://github.com/aldeed/meteor-collection2#inserting-or-updating-bypassing-collection2-entirely), cleaning and autovalues. Defaults to `false` if collection2 is installed, and will use collection2 to validate and clean entries when they're imported.
+* `enableHooks` optionally choose to enable before and after submit hooks, if the collection-hooks package is installed. Defaults to `false`, where the hooks will not be executed, instead using [collection.direct](https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks).
 
 ### examples
 
@@ -27,24 +44,21 @@ To export collection `col1`:
 
 To import collections `col1` & `col2` from instance `http://xx.yy.zz`:
 
-	Meteor.call('mm_import', 'http://xx.yy.zz', ['col1', 'col2'], 'destinationPassword', 'sourcePassword');
+	Meteor.call('mm_import', {
+	  sourceUrl: "http://xx.yy.zz",
+	  sourcePassword: "PASSWORD1",
+	  collections: ["col1", "col2"],
+	  localPassword: "PASSWORD2"
+	})
 
-### Todo move to this syntax:
+To import collections without having collection2 meddle with your records:
 
-Mindmeld.import({
-  sourceUrl: "",
-  sourcePassword: "",
-  collections: [],
-  localPassword: "", // only if running from the client
-
-  keepCurrentData: false,
-  disableValidation: false, // enables https://github.com/aldeed/meteor-collection2#passing-options
-  enableHooks: false // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
-})
-
-Meteor.Settings = {
-  mindmeld: {
-    password: "",
-    allowImport: false
-  }
-}
+	Meteor.call('mm_import', {
+	  sourceUrl: "http://xx.yy.zz",
+	  sourcePassword: "PASSWORD1",
+	  collections: ["col1", "col2"],
+	  localPassword: "PASSWORD2",
+	  keepCurrentData: false,
+	  bypassCollection2: true,
+	  enableHooks: false
+	})

--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ To export collection `col1`:
 To import collections `col1` & `col2` from instance `http://xx.yy.zz`:
 
 	Meteor.call('mm_import', 'http://xx.yy.zz', ['col1', 'col2'], 'destinationPassword', 'sourcePassword');
+
+### Todo move to this syntax:
+
+Mindmeld.import({
+  sourceUrl: "",
+  sourcePassword: "",
+  collections: [],
+  localPassword: "", // only if running from the client
+
+  keepCurrentData: false,
+  disableValidation: false, // enables https://github.com/aldeed/meteor-collection2#passing-options
+  enableHooks: false // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
+})
+
+Meteor.Settings = {
+  mindmeld: {
+    password: "",
+    allowImport: false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Then add these settings to `settings.json`:
 ## Usage
 Mind Meld exposes 2 DDP methods: `mm_import` and `mm_export`. Combined, these enable transfer of full collections between applications. Both can be called from a browser console but they are protected with a password (`Meteor.settings.mindMeld.password`).
 
-## `mm_export(collectionName, password)`
+## `MindMeld.export(collectionName, password)`
 The `mm_export` method returns a dump of the collection. You generally don't call this method yourself.
 
-## `mm_import({sourceUrl, sourcePassword, collections, localPassword, ...options})`
+## `MindMeld.import({sourceUrl, sourcePassword, collections, localPassword, ...options})`
 The `mm_import` method first calls `mm_export` on another Meteor instance, retrieving a collection dump, and imports the dump locally.
 
 Because this method default removes all records from your database, you have to specifically enable it using `Meteor.settings.mindMeld.allowImport`. Normally you would disable this on your production system, and enable it on your development and acceptance environments.
@@ -40,11 +40,11 @@ Parameters:
 
 To export collection `col1`:
 
-	Meteor.call('mm_export', 'col1', 'password');
+	MindMeld.export('col1', 'password');
 
 To import collections `col1` & `col2` from instance `http://xx.yy.zz`:
 
-	Meteor.call('mm_import', {
+	MindMeld.import({
 	  sourceUrl: "http://xx.yy.zz",
 	  sourcePassword: "PASSWORD1",
 	  collections: ["col1", "col2"],
@@ -53,7 +53,7 @@ To import collections `col1` & `col2` from instance `http://xx.yy.zz`:
 
 To import collections without having collection2 meddle with your records:
 
-	Meteor.call('mm_import', {
+	MindMeld.import({
 	  sourceUrl: "http://xx.yy.zz",
 	  sourcePassword: "PASSWORD1",
 	  collections: ["col1", "col2"],

--- a/mind-meld-client.js
+++ b/mind-meld-client.js
@@ -1,0 +1,11 @@
+MindMeld = {
+  export(collectionName, password) {
+    Meteor.call('mm_export', collectionName, password, function(err, res) {
+      if (err) console.warn(err);
+      console.log('[MindMeld] exporting', res);
+    });
+  },
+  import(options) {
+    Meteor.call('mm_import', options);
+  }
+}

--- a/mind-meld-client.js
+++ b/mind-meld-client.js
@@ -1,9 +1,6 @@
 MindMeld = {
-  export(collectionName, password) {
-    Meteor.call('mm_export', collectionName, password, function(err, res) {
-      if (err) console.warn(err);
-      console.log('[MindMeld] exporting', res);
-    });
+  export(collectionName, password, callBack) {
+    Meteor.call('mm_export', collectionName, password, callBack);
   },
   import(options) {
     Meteor.call('mm_import', options);

--- a/mind-meld-server.js
+++ b/mind-meld-server.js
@@ -1,11 +1,22 @@
 
 Meteor.methods({
   mm_export(collectionName, password) {
+    return MindMeld.export(collectionName, password);
+  },
+
+  mm_import(options) {
+    MindMeld.import(options);
+  }
+});
+
+
+MindMeld = {
+  export(collectionName, password) {
     check(collectionName, String);
     check(password, String);
 
     if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.password)
-      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password');
+      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password, not exporting');
 
     if (password !== Meteor.settings.mindMeld.password)
       throw new Meteor.Error('incorrect export password');
@@ -13,7 +24,7 @@ Meteor.methods({
     return MindMeld._export(collectionName);
   },
 
-  mm_import(options) {
+  import(options) {
     check(options, {
       sourceUrl: String,
       sourcePassword: String,
@@ -26,7 +37,7 @@ Meteor.methods({
     });
 
     if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.password)
-      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password');
+      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password, not importing');
 
     if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.allowImport)
       throw new Meteor.Error('import not allowed according to Meteor.settings.mindMeld.allowImport');
@@ -35,18 +46,16 @@ Meteor.methods({
       throw new Meteor.Error('incorrect localPassword');
 
     MindMeld._import(options);
-  }
-});
+  },
 
-
-MindMeld = {
   _export(collectionName) {
     const collection = Mongo.Collection.get(collectionName);
     if (!collection || !(collection instanceof Mongo.Collection ))
       throw new Meteor.Error(collectionName + ' is not a valid collection');
 
-    console.log("[MindMeld] dumping " + collectionName);
-    return collection.find({}).fetch();
+    const result = collection.find({}).fetch();
+    console.log("[MindMeld] dumping " + result.length + " records for " + collectionName);
+    return result;
   },
 
   _import(options) {

--- a/mind-meld-server.js
+++ b/mind-meld-server.js
@@ -5,6 +5,12 @@ Meteor.methods({
   },
 
   mm_import(options) {
+    if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.password)
+      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password, not importing');
+
+    if (options.localPassword !== Meteor.settings.mindMeld.password)
+      throw new Meteor.Error('incorrect localPassword');
+
     MindMeld.import(options);
   }
 });
@@ -29,7 +35,7 @@ MindMeld = {
       sourceUrl: String,
       sourcePassword: String,
       collections: [String],
-      localPassword: String, // only if running from the client
+      localPassword: Match.Optional(String), // only if running from the client
 
       keepCurrentData: Match.Optional(Boolean),
       bypassCollection2: Match.Optional(Boolean), // enables https://github.com/aldeed/meteor-collection2#inserting-or-updating-bypassing-collection2-entirely
@@ -41,9 +47,6 @@ MindMeld = {
 
     if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.allowImport)
       throw new Meteor.Error('import not allowed according to Meteor.settings.mindMeld.allowImport');
-
-    if (options.localPassword !== Meteor.settings.mindMeld.password)
-      throw new Meteor.Error('incorrect localPassword');
 
     MindMeld._import(options);
   },

--- a/mind-meld.js
+++ b/mind-meld.js
@@ -25,11 +25,11 @@ Meteor.methods({
       enableHooks: Match.Optional(Boolean) // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
     });
 
+    if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.password)
+      throw new Meteor.Error('no password set in Meteor.settings.mindmeld.password');
+
     if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.allowImport)
       throw new Meteor.Error('import not allowed according to Meteor.settings.mindmeld.allowImport');
-
-    if (!Meteor.settings.mindmeld.password)
-      throw new Meteor.Error('no password set in Meteor.settings.mindmeld.password');
 
     if (options.localPassword !== Meteor.settings.mindmeld.password)
       throw new Meteor.Error('incorrect localPassword');
@@ -62,7 +62,7 @@ MindMeld = {
 
     const dump = connection.call("mm_export", collectionName, options.sourcePassword);
     if (!dump || !dump.length) {
-      console.log('[MindMeld] nothing to import');
+      console.log('[MindMeld] nothing to import for ' + collectionName);
       return;
     }
 
@@ -88,4 +88,4 @@ MindMeld = {
 
 };
 
-Meteor.startup(() => !(Meteor.settings.mindmeld && Meteor.settings.mindmeld.password) && console.warn('MindMeld: no token set'));
+Meteor.startup(() => !(Meteor.settings.mindmeld && Meteor.settings.mindmeld.password) && console.warn('MindMeld: no password set at Meteor.settings.mindmeld.password'));

--- a/mind-meld.js
+++ b/mind-meld.js
@@ -20,9 +20,9 @@ Meteor.methods({
       collections: [String],
       localPassword: String, // only if running from the client
 
-      keepCurrentData: Boolean,
-      bypassCollection2: Boolean, // enables https://github.com/aldeed/meteor-collection2#inserting-or-updating-bypassing-collection2-entirely
-      enableHooks: Boolean // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
+      keepCurrentData: Match.Optional(Boolean),
+      bypassCollection2: Match.Optional(Boolean), // enables https://github.com/aldeed/meteor-collection2#inserting-or-updating-bypassing-collection2-entirely
+      enableHooks: Match.Optional(Boolean) // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
     });
 
     if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.allowImport)

--- a/mind-meld.js
+++ b/mind-meld.js
@@ -21,6 +21,9 @@ Meteor.methods({
 
     if (!Meteor.settings.MIND_MELD_TOKEN)
       throw new Meteor.Error('no token set');
+      
+    if (Meteor.isProduction)
+      throw new Meteor.Error('importing not allowed on production deployment, to secure your data');
 
     if (password1 !== Meteor.settings.MIND_MELD_TOKEN)
       throw new Meteor.Error('incorrect password: ' + password1);

--- a/mind-meld.js
+++ b/mind-meld.js
@@ -4,10 +4,10 @@ Meteor.methods({
     check(collectionName, String);
     check(password, String);
 
-    if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.password)
-      throw new Meteor.Error('no password set in Meteor.settings.mindmeld.password');
+    if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.password)
+      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password');
 
-    if (password !== Meteor.settings.mindmeld.password)
+    if (password !== Meteor.settings.mindMeld.password)
       throw new Meteor.Error('incorrect export password');
 
     return MindMeld.export(collectionName);
@@ -25,13 +25,13 @@ Meteor.methods({
       enableHooks: Match.Optional(Boolean) // enables https://github.com/matb33/meteor-collection-hooks#direct-access-circumventing-hooks
     });
 
-    if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.password)
-      throw new Meteor.Error('no password set in Meteor.settings.mindmeld.password');
+    if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.password)
+      throw new Meteor.Error('no password set in Meteor.settings.mindMeld.password');
 
-    if (!Meteor.settings.mindmeld || !Meteor.settings.mindmeld.allowImport)
-      throw new Meteor.Error('import not allowed according to Meteor.settings.mindmeld.allowImport');
+    if (!Meteor.settings.mindMeld || !Meteor.settings.mindMeld.allowImport)
+      throw new Meteor.Error('import not allowed according to Meteor.settings.mindMeld.allowImport');
 
-    if (options.localPassword !== Meteor.settings.mindmeld.password)
+    if (options.localPassword !== Meteor.settings.mindMeld.password)
       throw new Meteor.Error('incorrect localPassword');
 
     MindMeld.import(options);
@@ -88,4 +88,4 @@ MindMeld = {
 
 };
 
-Meteor.startup(() => !(Meteor.settings.mindmeld && Meteor.settings.mindmeld.password) && console.warn('MindMeld: no password set at Meteor.settings.mindmeld.password'));
+Meteor.startup(() => !(Meteor.settings.mindMeld && Meteor.settings.mindMeld.password) && console.warn('MindMeld: no password set at Meteor.settings.mindMeld.password'));

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'q42:mind-meld',
   version: '1.0.0',
   summary: 'Easily transfer collection data between Meteor instances.',
-  git: '',
+  git: 'https://github.com/Q42/meteor-mind-meld',
   documentation: 'README.md'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'q42:mind-meld',
-  version: '0.0.1',
+  version: '1.0.0',
   summary: 'Easily transfer collection data between Meteor instances.',
   git: '',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'q42:mind-meld',
-  version: '1.0.0',
+  version: '1.0.1',
   summary: 'Easily transfer collection data between Meteor instances.',
   git: 'https://github.com/Q42/meteor-mind-meld',
   documentation: 'README.md'
@@ -11,6 +11,7 @@ Package.onUse(function(api) {
   api.use('ecmascript');
   api.use('check');
   api.use('dburles:mongo-collection-instances@0.3.4');
-  api.addFiles('mind-meld.js', 'server');
+  api.addFiles('mind-meld-server.js', 'server');
+  api.addFiles('mind-meld-client.js', 'client');
   api.export('MindMeld');
 });


### PR DESCRIPTION
Fixes #3 and #1 

added meteor.settings.mindmeld.allowImport to default disable importing on production systems as it will potentially wipe the database

added options for enabling and disabling collection2 and collection-hooks, or appending to the current collection instead of replacing it
